### PR TITLE
FIX error when click on "reservations summary"

### DIFF
--- a/hotel_reservation/models/hotel_reservation.py
+++ b/hotel_reservation/models/hotel_reservation.py
@@ -735,7 +735,10 @@ class RoomReservationSummary(models.Model):
                 raise except_orm(_('User Error!'),
                                  _('Please Check Time period Date \
                                  From can\'t be greater than Date To !'))
-            timezone = pytz.timezone(self._context.get('tz', False))
+            if self._context.get('tz', False):
+                timezone = pytz.timezone(self._context.get('tz', False))
+            else:
+                timezone = pytz.timezone('UTC')
             d_frm_obj = dtime.strptime(self.date_from, dt)\
                 .replace(tzinfo=pytz.timezone('UTC')).astimezone(timezone)
             d_to_obj = dtime.strptime(self.date_to, dt)\


### PR DESCRIPTION
Traceback : File "/home/odoo/addons/hotel_reservation/models/hotel_reservation.py", line 738, in get_room_summary
    if self._context.get('tz', False):
  File "/usr/local/lib/python2.7/dist-packages/pytz/__init__.py", line 163, in timezone
    if zone.upper() == 'UTC':
AttributeError: 'bool' object has no attribute 'upper'

To solve this problem i test first if something exist in "self._context.get('tz', False)", if not i define "timezone"